### PR TITLE
fix: remove broad lib/** pattern from upstream change detection

### DIFF
--- a/.github/workflows/pull-from-bazel-build.yml
+++ b/.github/workflows/pull-from-bazel-build.yml
@@ -96,7 +96,6 @@ jobs:
           sha: ${{ inputs.bazelCommitHash }}
           files: |
             docs/**
-            src/main/java/com/google/devtools/build/lib/**
             src/main/java/com/google/devtools/build/docgen/**
             src/main/starlark/docgen/**
             tools/build_defs/repo/**


### PR DESCRIPTION
## Summary

- Removes `src/main/java/com/google/devtools/build/lib/**` from the changed-files filter in `pull-from-bazel-build.yml`
- This pattern matched virtually all of Bazel's Java source tree, causing the preview pipeline to trigger on PRs that have no doc-related changes
- The remaining patterns (`docs/**`, `src/main/java/com/google/devtools/build/docgen/**`, `src/main/starlark/docgen/**`, etc.) are sufficient to catch actual doc changes
