### PR TITLE
fix(.mintignore): remove concepts pages fixed in bazelbuild/bazel#28866

### DIFF
--- a/.mintignore
+++ b/.mintignore
@@ -38,12 +38,6 @@
 # "Could not parse expression with acorn" — bare {..} in prose
 **/community/roadmaps-configurability.mdx
 **/community/users.mdx
-# "Could not parse expression with acorn" — bare {..} in prose
-**/concepts/build-files.mdx
-# "Could not parse import/exports with acorn" — bare {..} in prose
-**/concepts/dependencies.mdx
-# "Could not parse expression with acorn" — bare {..} in prose
-**/concepts/labels.mdx
 **/concepts/visibility.mdx
 **/contribute/search.mdx
 **/docs/cc-toolchain-config-reference.mdx


### PR DESCRIPTION
## Summary

- Removes `concepts/build-files.mdx`, `concepts/dependencies.mdx`, and `concepts/labels.mdx` from `.mintignore`
- These files had bare `{..}` MDX parse errors that are fixed in the upstream PR bazelbuild/bazel#28866
- Once that PR merges, these pages should render correctly and appear in navigation

## Test plan

- [ ] Confirm bazelbuild/bazel#28866 is merged before merging this
- [ ] Verify the three concepts pages render without errors in the Mintlify preview

Relates to #226 
