### PR TITLE
fix: preserve versioned nav files during upstream sync

### DIFF
--- a/navigation.update.sh
+++ b/navigation.update.sh
@@ -40,9 +40,35 @@ VERSIONS=$(echo "HEAD"; echo "$FILTERED" | grep -v '^$' | sort -Vr)
 TABS_FILE="docs-tabs.json"
 NAV_DIR="navigation"
 
-# Clean and recreate the per-version directory
-rm -f "$NAV_DIR"/*.json
+# Only regenerate the HEAD nav; preserve existing versioned nav files so that
+# Dependabot submodule bumps don't overwrite manual fixes (see #346).
+rm -f "$NAV_DIR/HEAD.en.json"
 mkdir -p "$NAV_DIR"
+
+# Remove pages from a nav file whose .mdx files don't exist on disk.
+filter_missing_pages() {
+    local nav_file="$1"
+    local pages
+    pages=$(jq -r '.tabs | .. | .pages? // empty | .[]' "$nav_file")
+
+    local missing=()
+    while IFS= read -r page; do
+        [ -z "$page" ] && continue
+        if [ ! -f "${page}.mdx" ]; then
+            missing+=("$page")
+        fi
+    done <<< "$pages"
+
+    if [ ${#missing[@]} -gt 0 ]; then
+        local to_remove
+        to_remove=$(printf '%s\n' "${missing[@]}" | jq -R . | jq -sc '.')
+        local tmp
+        tmp=$(jq --argjson remove "$to_remove" \
+            'walk(if type == "array" then map(select(. as $p | ($p | type) != "string" or ($remove | index($p) | not))) else . end)' \
+            "$nav_file")
+        echo "$tmp" > "$nav_file"
+    fi
+}
 
 # Build the $ref list for navigation.json as we write each file
 REFS_JSON="["
@@ -60,15 +86,25 @@ for version in $VERSIONS; do
         jq -n --argjson tabs "$TABS_JSON" \
             '{"language":"en","tabs":$tabs}' \
             > "$NAV_DIR/HEAD.en.json"
+        filter_missing_pages "$NAV_DIR/HEAD.en.json"
         REFS_JSON="$REFS_JSON{\"version\":\"HEAD\",\"languages\":[{\"\$ref\":\"./navigation/HEAD.en.json\"}]}"
     else
         DISPLAY_VERSION=$(echo "$version" | sed 's/\.[0-9]*$//')
-        TABS_JSON=$(jq -c --arg version "$version" '
-            map(.groups = (.groups | map(.pages = (.pages | map("versions/" + $version + "/" + .)))))
-        ' "$TABS_FILE")
-        jq -n --argjson tabs "$TABS_JSON" \
-            '{"language":"en","tabs":$tabs}' \
-            > "$NAV_DIR/$DISPLAY_VERSION.en.json"
+        NAV_FILE="$NAV_DIR/$DISPLAY_VERSION.en.json"
+
+        if [ -f "$NAV_FILE" ]; then
+            echo "Keeping existing $DISPLAY_VERSION navigation"
+        else
+            echo "Creating new $DISPLAY_VERSION navigation"
+            TABS_JSON=$(jq -c --arg version "$version" '
+                map(.groups = (.groups | map(.pages = (.pages | map("versions/" + $version + "/" + .)))))
+            ' "$TABS_FILE")
+            jq -n --argjson tabs "$TABS_JSON" \
+                '{"language":"en","tabs":$tabs}' \
+                > "$NAV_FILE"
+            filter_missing_pages "$NAV_FILE"
+        fi
+
         REFS_JSON="$REFS_JSON{\"version\":\"$DISPLAY_VERSION\",\"languages\":[{\"\$ref\":\"./navigation/$DISPLAY_VERSION.en.json\"}]}"
     fi
 done


### PR DESCRIPTION
## Summary
- Stop regenerating existing versioned navigation files on every upstream sync — only HEAD nav is rebuilt each time
- New versions still get nav files created (with file-existence filtering to exclude pages whose .mdx does not exist)
- Prevents Dependabot submodule bumps from overwriting manual fixes to versioned nav files (e.g. #341)

Closes #346

## Test plan
- [x] Run `./navigation.update.sh` — existing versioned nav files should be preserved (prints `Keeping existing …`)
- [x] Delete one versioned nav file and re-run — it should be recreated with non-existent pages filtered out
- [x] Verify `navigation.json` still lists all versions correctly

## Test evidence

### 1. Existing versioned nav files are preserved

Checksum of `navigation/8.0.en.json` before and after running the script — identical:

```
$ md5 -q navigation/8.0.en.json
c93e87bbf320216891d559b921fdb71a

$ ./navigation.update.sh
Keeping existing 9.0 navigation
Keeping existing 8.6 navigation
Keeping existing 8.5 navigation
Keeping existing 8.4 navigation
Keeping existing 8.3 navigation
Keeping existing 8.2 navigation
Keeping existing 8.1 navigation
Keeping existing 8.0 navigation
Keeping existing 7.7 navigation
Keeping existing 6.5 navigation
Created navigation.json + 11 files in navigation/

$ md5 -q navigation/8.0.en.json
c93e87bbf320216891d559b921fdb71a
```

### 2. Deleted nav file is recreated with file-existence filtering

After deleting `navigation/8.0.en.json` and re-running, the script creates a new one and filters out pages whose `.mdx` files don't exist in 8.0.1:

```
$ rm navigation/8.0.en.json && ./navigation.update.sh
...
Creating new 8.0 navigation
...

$ ls versions/8.0.1/community/experts.mdx
ls: versions/8.0.1/community/experts.mdx: No such file or directory
$ ls versions/8.0.1/community/partners.mdx
ls: versions/8.0.1/community/partners.mdx: No such file or directory

$ jq '.tabs[] | select(.tab == "Community") | .groups[] | select(.group == "Programs") | .pages' navigation/8.0.en.json
[
  "versions/8.0.1/community/sig",
  "versions/8.0.1/community/users",
  "versions/8.0.1/community/recommended-rules",
  "versions/8.0.1/community/remote-execution-services"
]
```

`community/experts` and `community/partners` (which exist in HEAD's `docs-tabs.json` but not in 8.0.1) were correctly excluded.

### 3. navigation.json lists all versions

```
$ jq '.versions[].version' navigation.json
"HEAD"
"9.0"
"8.6"
"8.5"
"8.4"
"8.3"
"8.2"
"8.1"
"8.0"
"7.7"
"6.5"
```