### PR TITLE
Fix/delete missing pages in .json files (again)

### DIFF
--- a/navigation/6.5.en.json
+++ b/navigation/6.5.en.json
@@ -8,7 +8,6 @@
           "group": "Why Bazel?",
           "pages": [
             "versions/6.5.0/about/intro",
-            "versions/6.5.0/about/why",
             "versions/6.5.0/about/vision",
             "versions/6.5.0/about/faq"
           ]
@@ -74,9 +73,7 @@
           "group": "Releases",
           "pages": [
             "versions/6.5.0/release/index",
-            "versions/6.5.0/release/rolling",
-            "versions/6.5.0/release/backward-compatibility",
-            "versions/6.5.0/release/rule-compatibility"
+            "versions/6.5.0/release/backward-compatibility"
           ]
         },
         {
@@ -95,12 +92,7 @@
             "versions/6.5.0/configure/integrate-cpp",
             "versions/6.5.0/configure/coverage",
             "versions/6.5.0/configure/best-practices",
-            "versions/6.5.0/configure/windows",
-            "versions/6.5.0/advanced/performance/build-performance-metrics",
-            "versions/6.5.0/advanced/performance/build-performance-breakdown",
-            "versions/6.5.0/advanced/performance/json-trace-profile",
-            "versions/6.5.0/advanced/performance/memory",
-            "versions/6.5.0/advanced/performance/iteration-speed"
+            "versions/6.5.0/configure/windows"
           ]
         },
         {
@@ -148,19 +140,11 @@
       "groups": [
         {
           "group": "Build encyclopedia",
-          "pages": [
-            "versions/6.5.0/reference/be/overview",
-            "versions/6.5.0/reference/be/common-definitions",
-            "versions/6.5.0/reference/be/make-variables",
-            "versions/6.5.0/reference/be/functions",
-            "versions/6.5.0/reference/be/platforms-and-toolchains"
-          ]
+          "pages": []
         },
         {
           "group": "Command line reference",
-          "pages": [
-            "versions/6.5.0/reference/command-line-reference"
-          ]
+          "pages": []
         },
         {
           "group": "Query Language",
@@ -177,9 +161,7 @@
         },
         {
           "group": "Flag cheatsheet",
-          "pages": [
-            "versions/6.5.0/reference/flag-cheatsheet"
-          ]
+          "pages": []
         }
       ]
     },
@@ -197,7 +179,6 @@
           "pages": [
             "versions/6.5.0/rules/rules-tutorial",
             "versions/6.5.0/rules/macro-tutorial",
-            "versions/6.5.0/rules/legacy-macro-tutorial",
             "versions/6.5.0/rules/verbs-tutorial",
             "versions/6.5.0/rules/language",
             "versions/6.5.0/rules/bzl-style",
@@ -215,23 +196,11 @@
         },
         {
           "group": "APIs",
-          "pages": [
-            "versions/6.5.0/rules/lib/overview",
-            "versions/6.5.0/rules/lib/globals",
-            "versions/6.5.0/rules/lib/globals/bzl",
-            "versions/6.5.0/rules/lib/globals/module"
-          ]
+          "pages": []
         },
         {
           "group": "Repo rules",
-          "pages": [
-            "versions/6.5.0/rules/lib/repo/index",
-            "versions/6.5.0/rules/lib/repo/cache",
-            "versions/6.5.0/rules/lib/repo/git",
-            "versions/6.5.0/rules/lib/repo/http",
-            "versions/6.5.0/rules/lib/repo/local",
-            "versions/6.5.0/rules/lib/repo/utils"
-          ]
+          "pages": []
         }
       ]
     },
@@ -247,7 +216,6 @@
             "versions/6.5.0/contribute/maintainers-guide",
             "versions/6.5.0/contribute/codebase",
             "versions/6.5.0/contribute/search",
-            "versions/6.5.0/contribute/statemachine-guide",
             "versions/6.5.0/contribute/docs",
             "versions/6.5.0/contribute/docs-style-guide",
             "versions/6.5.0/contribute/design-documents",
@@ -258,8 +226,6 @@
           "group": "Programs",
           "pages": [
             "versions/6.5.0/community/sig",
-            "versions/6.5.0/community/experts",
-            "versions/6.5.0/community/partners",
             "versions/6.5.0/community/users",
             "versions/6.5.0/community/recommended-rules",
             "versions/6.5.0/community/remote-execution-services"

--- a/navigation/7.7.en.json
+++ b/navigation/7.7.en.json
@@ -8,7 +8,6 @@
           "group": "Why Bazel?",
           "pages": [
             "versions/7.7.1/about/intro",
-            "versions/7.7.1/about/why",
             "versions/7.7.1/about/vision",
             "versions/7.7.1/about/faq"
           ]
@@ -74,7 +73,6 @@
           "group": "Releases",
           "pages": [
             "versions/7.7.1/release/index",
-            "versions/7.7.1/release/rolling",
             "versions/7.7.1/release/backward-compatibility",
             "versions/7.7.1/release/rule-compatibility"
           ]
@@ -177,9 +175,7 @@
         },
         {
           "group": "Flag cheatsheet",
-          "pages": [
-            "versions/7.7.1/reference/flag-cheatsheet"
-          ]
+          "pages": []
         }
       ]
     },
@@ -197,7 +193,6 @@
           "pages": [
             "versions/7.7.1/rules/rules-tutorial",
             "versions/7.7.1/rules/macro-tutorial",
-            "versions/7.7.1/rules/legacy-macro-tutorial",
             "versions/7.7.1/rules/verbs-tutorial",
             "versions/7.7.1/rules/language",
             "versions/7.7.1/rules/bzl-style",
@@ -258,8 +253,6 @@
           "group": "Programs",
           "pages": [
             "versions/7.7.1/community/sig",
-            "versions/7.7.1/community/experts",
-            "versions/7.7.1/community/partners",
             "versions/7.7.1/community/users",
             "versions/7.7.1/community/recommended-rules",
             "versions/7.7.1/community/remote-execution-services"

--- a/navigation/8.0.en.json
+++ b/navigation/8.0.en.json
@@ -258,8 +258,6 @@
           "group": "Programs",
           "pages": [
             "versions/8.0.1/community/sig",
-            "versions/8.0.1/community/experts",
-            "versions/8.0.1/community/partners",
             "versions/8.0.1/community/users",
             "versions/8.0.1/community/recommended-rules",
             "versions/8.0.1/community/remote-execution-services"

--- a/navigation/8.1.en.json
+++ b/navigation/8.1.en.json
@@ -258,8 +258,6 @@
           "group": "Programs",
           "pages": [
             "versions/8.1.1/community/sig",
-            "versions/8.1.1/community/experts",
-            "versions/8.1.1/community/partners",
             "versions/8.1.1/community/users",
             "versions/8.1.1/community/recommended-rules",
             "versions/8.1.1/community/remote-execution-services"

--- a/navigation/8.2.en.json
+++ b/navigation/8.2.en.json
@@ -258,8 +258,6 @@
           "group": "Programs",
           "pages": [
             "versions/8.2.1/community/sig",
-            "versions/8.2.1/community/experts",
-            "versions/8.2.1/community/partners",
             "versions/8.2.1/community/users",
             "versions/8.2.1/community/recommended-rules",
             "versions/8.2.1/community/remote-execution-services"

--- a/navigation/8.3.en.json
+++ b/navigation/8.3.en.json
@@ -258,8 +258,6 @@
           "group": "Programs",
           "pages": [
             "versions/8.3.1/community/sig",
-            "versions/8.3.1/community/experts",
-            "versions/8.3.1/community/partners",
             "versions/8.3.1/community/users",
             "versions/8.3.1/community/recommended-rules",
             "versions/8.3.1/community/remote-execution-services"

--- a/navigation/8.4.en.json
+++ b/navigation/8.4.en.json
@@ -258,8 +258,6 @@
           "group": "Programs",
           "pages": [
             "versions/8.4.2/community/sig",
-            "versions/8.4.2/community/experts",
-            "versions/8.4.2/community/partners",
             "versions/8.4.2/community/users",
             "versions/8.4.2/community/recommended-rules",
             "versions/8.4.2/community/remote-execution-services"

--- a/navigation/8.5.en.json
+++ b/navigation/8.5.en.json
@@ -258,8 +258,6 @@
           "group": "Programs",
           "pages": [
             "versions/8.5.1/community/sig",
-            "versions/8.5.1/community/experts",
-            "versions/8.5.1/community/partners",
             "versions/8.5.1/community/users",
             "versions/8.5.1/community/recommended-rules",
             "versions/8.5.1/community/remote-execution-services"

--- a/navigation/8.6.en.json
+++ b/navigation/8.6.en.json
@@ -258,8 +258,6 @@
           "group": "Programs",
           "pages": [
             "versions/8.6.0/community/sig",
-            "versions/8.6.0/community/experts",
-            "versions/8.6.0/community/partners",
             "versions/8.6.0/community/users",
             "versions/8.6.0/community/recommended-rules",
             "versions/8.6.0/community/remote-execution-services"

--- a/navigation/9.0.en.json
+++ b/navigation/9.0.en.json
@@ -258,8 +258,6 @@
           "group": "Programs",
           "pages": [
             "versions/9.0.0/community/sig",
-            "versions/9.0.0/community/experts",
-            "versions/9.0.0/community/partners",
             "versions/9.0.0/community/users",
             "versions/9.0.0/community/recommended-rules",
             "versions/9.0.0/community/remote-execution-services"


### PR DESCRIPTION
This change re-applies https://github.com/bazel-contrib/bazel-docs/pull/341, which was accidentally reverted by dependabot in https://github.com/bazel-contrib/bazel-docs/pull/344.