### PR TITLE
Add initial Bazel CI presubmit config

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,0 +1,6 @@
+---
+check_docs: 1
+tasks:
+  ubuntu2404:
+    shell_commands:
+      - echo "OK"  # TODO: replace with proper tests

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,1 @@
+module(name = "bazel-docs", version = "1.0")


### PR DESCRIPTION
Example: https://buildkite.com/bazel/bazel-books-bazel-docs/builds/563#019d9d1a-d14d-4a41-9b0c-03a9b6cfb207

The presubmit is currently failing because of the missing 8.6 reference docs (https://github.com/bazelbuild/bazel/issues/28930) and the fact that https://github.com/bazel-contrib/bazel-docs/pull/373 is still pending, so we shouldn't enable it just yet.

Progress towards https://github.com/bazelbuild/continuous-integration/issues/2555