### PR TITLE
Link the skyframe and skyframe-debugging docs from the reference

### DIFF
--- a/docs-tabs.json
+++ b/docs-tabs.json
@@ -178,6 +178,13 @@
         "pages": [
           "reference/flag-cheatsheet"
         ]
+      },
+      {
+        "group": "Skyframe",
+        "pages": [
+          "reference/skyframe",
+          "reference/skyframe-debugging"
+        ]
       }
     ]
   },


### PR DESCRIPTION
sidebar.