### PR TITLE
ci: stop executing fork PR code with repo secrets

### DIFF
--- a/.github/workflows/preview-bazel-docs-pr.yml
+++ b/.github/workflows/preview-bazel-docs-pr.yml
@@ -47,6 +47,7 @@ jobs:
               head_sha: .head.sha,
               base_sha: .base.sha,
               head_ref: .head.ref,
+              head_repo_fork: (if .head.repo == null then true else .head.repo.fork end),
               preview_branch: ("pr-" + (.number|tostring))
             }]')"
           else
@@ -64,6 +65,7 @@ jobs:
                   head_sha: .head.sha,
                   base_sha: .base.sha,
                   head_ref: .head.ref,
+                  head_repo_fork: (if .head.repo == null then true else .head.repo.fork end),
                   preview_branch: ("pr-" + (.number|tostring))
                 }
               ]
@@ -81,13 +83,21 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.list-prs.outputs.matrix) }}
     uses: ./.github/workflows/pull-from-bazel-build.yml
-    secrets: inherit
+    # Only the secrets this workflow actually needs; `inherit` would also expose
+    # unrelated repo secrets to a job that processes upstream PR content.
+    secrets:
+      GH_APP_ID: ${{ secrets.GH_APP_ID }}
+      GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
+      BUILDBUDDY_ORG_API_KEY: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
     with:
       bazelCommitHash: ${{ matrix.head_sha }}
       bazelBaseCommitHash: ${{ matrix.base_sha }}
       bazelPullRequestNumber: ${{ matrix.number }}
       detect_upstream_docs_changes: true
+      # Write access to this repo: always ours, previews are pushed here.
       is_internal_pr: true
+      # Executing upstream code: only for PRs from bazelbuild/bazel itself.
+      trust_upstream_code: ${{ !matrix.head_repo_fork }}
       target_branch: ${{ matrix.preview_branch }}
 
   comment:

--- a/.github/workflows/pull-from-bazel-build.yml
+++ b/.github/workflows/pull-from-bazel-build.yml
@@ -33,6 +33,24 @@ on:
         required: false
         type: boolean
         default: false
+      trust_upstream_code:
+        description: >
+          Whether the upstream commit being checked out is trusted enough to execute.
+          Building reference docs runs Bazel over upstream BUILD/Starlark files, which is
+          arbitrary code execution. Must be false for commits from forks. Distinct from
+          is_internal_pr, which controls write access to *this* repo.
+        required: false
+        type: boolean
+        default: true
+    secrets:
+      # Declared explicitly so callers can pass a narrowed set instead of `secrets: inherit`.
+      # Callers that still use `inherit` keep working.
+      GH_APP_ID:
+        required: false
+      GH_APP_PRIVATE_KEY:
+        required: false
+      BUILDBUDDY_ORG_API_KEY:
+        required: false
 
 jobs:
   pull-fresh-upstream:
@@ -57,6 +75,10 @@ jobs:
         with:
           submodules: false
           token: ${{ steps.generate-token.outputs.token }}
+          # Keep the App token out of .git/config, where later steps — including
+          # anything the upstream build spawns — could read it. Pushes below supply
+          # it from the environment instead.
+          persist-credentials: false
 
       - name: Checkout repository (fork)
         if: ${{ !inputs.is_internal_pr }}
@@ -65,6 +87,20 @@ jobs:
           submodules: false
           # No token is provided, so the action will use the default GITHUB_TOKEN
           # with fork-safe, read-only permissions.
+          persist-credentials: false
+
+      - name: Configure Git credentials
+        if: ${{ inputs.is_internal_pr }}
+        env:
+          GH_APP_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Helper reads the token from the environment at push time, so it is never
+          # written to disk or passed as a process argument.
+          git config credential.helper \
+            '!f() { echo username=x-access-token; echo "password=${GH_APP_TOKEN}"; }; f'
 
       - name: Checkout submodules
         run: git submodule update --init -- upstream
@@ -89,7 +125,7 @@ jobs:
       - name: Get changed files in upstream
         id: changed-files
         if: ${{ inputs.detect_upstream_docs_changes }}
-        uses: tj-actions/changed-files@v47.0.6
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           path: upstream
           base_sha: ${{ inputs.bazelBaseCommitHash }}
@@ -120,6 +156,7 @@ jobs:
         if: ${{ inputs.is_internal_pr && inputs.target_branch != '' && steps.docs-changes.outputs.should_run == 'true' }}
         env:
           TARGET_BRANCH: ${{ inputs.target_branch }}
+          GH_APP_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           set -euo pipefail
           if git ls-remote --exit-code --heads origin "${TARGET_BRANCH}" >/dev/null; then
@@ -129,28 +166,35 @@ jobs:
           git push origin "HEAD:${TARGET_BRANCH}"
 
       - name: Setup Bazel
-        if: ${{ steps.docs-changes.outputs.should_run == 'true' }}
+        if: ${{ inputs.is_internal_pr && inputs.trust_upstream_code && steps.docs-changes.outputs.should_run == 'true' }}
         uses: bazel-contrib/setup-bazel@0.19.0
         with:
           bazelisk-cache: true
           repository-cache: true
        
-      - name: Build reference documentation (if not a fork)
-        if: ${{ inputs.is_internal_pr && steps.docs-changes.outputs.should_run == 'true' }}
+      - name: Build reference documentation
+        # Runs Bazel over upstream BUILD/Starlark files, which is arbitrary code
+        # execution. Never run this for a commit from a fork.
+        if: ${{ inputs.is_internal_pr && inputs.trust_upstream_code && steps.docs-changes.outputs.should_run == 'true' }}
         working-directory: upstream
-        run: >
-          bazel build
-          --config=docs
-          --build_metadata=ROLE=DOCS
-          --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }}
-          --bes_results_url=https://app.buildbuddy.io/invocation/
-          --bes_backend=grpcs://remote.buildbuddy.io
-          --remote_cache=grpcs://remote.buildbuddy.io
-          --remote_timeout=10m
-          //src/main/java/com/google/devtools/build/lib:gen_mdx_reference_docs
+        env:
+          BUILDBUDDY_ORG_API_KEY: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
+        run: |
+          set -euo pipefail
+          # Keep the API key out of argv, where any process in the build could read it.
+          rcfile="$(mktemp)"
+          printf 'build --remote_header=x-buildbuddy-api-key=%s\n' "${BUILDBUDDY_ORG_API_KEY}" > "${rcfile}"
+          bazel --bazelrc="${rcfile}" build \
+            --config=docs \
+            --build_metadata=ROLE=DOCS \
+            --bes_results_url=https://app.buildbuddy.io/invocation/ \
+            --bes_backend=grpcs://remote.buildbuddy.io \
+            --remote_cache=grpcs://remote.buildbuddy.io \
+            --remote_timeout=10m \
+            //src/main/java/com/google/devtools/build/lib:gen_mdx_reference_docs
       
       - name: Upload reference docs artifact
-        if: ${{ steps.docs-changes.outputs.should_run == 'true' && github.ref != 'refs/heads/main' }}
+        if: ${{ inputs.is_internal_pr && inputs.trust_upstream_code && steps.docs-changes.outputs.should_run == 'true' && github.ref != 'refs/heads/main' }}
         uses: actions/upload-artifact@v7
         with:
           name: reference-docs
@@ -165,7 +209,7 @@ jobs:
           rsync -av --include='*/' --include='*.mdx' --include='*.md' --include='*.png' --include='*.jpg' --include='*.svg' --exclude='*' upstream/docs/ .
           
       - name: Extract MDX reference docs
-        if: ${{ inputs.is_internal_pr && steps.docs-changes.outputs.should_run == 'true' }}
+        if: ${{ inputs.is_internal_pr && inputs.trust_upstream_code && steps.docs-changes.outputs.should_run == 'true' }}
         run: |
           unzip -o upstream/bazel-bin/src/main/java/com/google/devtools/build/lib/mdx-reference-docs.zip -d .
 
@@ -191,17 +235,12 @@ jobs:
             done
           done < .mintignore
 
-      - name: Configure Git
-        if: ${{ inputs.is_internal_pr && steps.docs-changes.outputs.should_run == 'true' }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
       - name: Commit and push changes
         if: ${{ inputs.is_internal_pr && steps.docs-changes.outputs.should_run == 'true' }}
         env:
           BRANCH_OVERRIDE: ${{ inputs.target_branch }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          GH_APP_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
Fork PRs were built with `is_internal_pr: true`, so `bazel build` ran over upstream BUILD/Starlark from the fork while the runner held a push-capable App token, the BuildBuddy key on the command line, and every repo secret via `secrets: inherit`.

Adds a separate `trust_upstream_code` input so "we may write to this repo" and "this upstream code is safe to execute" stop being the same flag. Fork PRs take a data-only path: docs are rsynced and the preview branch is still published, but no upstream code runs and reference docs are skipped. 95 of the 100 currently-open bazel PRs are from forks, so previews had to keep working for them.

Also narrows the inherited secrets to the three actually used, moves the BuildBuddy key out of argv into a bazelrc, sets `persist-credentials: false`, and pins `tj-actions/changed-files` to a commit SHA.