### PR TITLE
Only garbage collect previews for closed PRs

### DIFF
--- a/.github/workflows/preview-bazel-docs-pr.yml
+++ b/.github/workflows/preview-bazel-docs-pr.yml
@@ -287,9 +287,9 @@ jobs:
 
             # Check if the upstream bazelbuild/bazel PR is still open
             state=$(GH_TOKEN="${BAZELBUILD_TOKEN}" gh api "repos/bazelbuild/bazel/pulls/${pr_number}" \
-              --jq '.state' 2>/dev/null || echo "not_found")
+              2>/dev/null | jq -r '.state // "unknown"')
 
-            if [[ "$state" == "open" ]]; then
+            if [[ "$state" != "closed" ]]; then
               continue
             fi
 


### PR DESCRIPTION
When GitHub goes down, the API call that checks if a PR has been closed can fail, which suggests that the associated PR is no longer open. This causes preview PRs to get garbage collected while the original Bazel-side PR is still active.

This changes the detection workflow to only close a preview PR if we're certain the PR has been closed.