### PR TITLE
Disable upstream cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
       interval: daily
       time: "23:00"
       timezone: "America/Los_Angeles"
+    cooldown:
+      exclude:
+        - "bazelbuild/bazel"
     open-pull-requests-limit: 3
     rebase-strategy: auto
 


### PR DESCRIPTION
Disable dependabot cooldown when rolling upstream. This prevents the rolls from lagging by a minimum of 3 days.